### PR TITLE
Update MForge.cs

### DIFF
--- a/CmlLib/CmlLib.csproj
+++ b/CmlLib/CmlLib.csproj
@@ -29,6 +29,7 @@ Support all version, forge, optifine
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="HtmlAgilityPack" Version="1.11.48" />
         <PackageReference Include="TunnelVisionLabs.ReferenceAssemblyAnnotator" Version="1.0.0-alpha.160" PrivateAssets="all" />
         <PackageDownload Include="Microsoft.NETCore.App.Ref" Version="[5.0.0]" />
         <PackageReference Include="ConfigureAwait.Fody" Version="3.3.1">

--- a/CmlLib/Core/Installer/MForge.cs
+++ b/CmlLib/Core/Installer/MForge.cs
@@ -365,20 +365,6 @@ namespace CmlLib.Core.Installer
             throw new Exception("The version was not found on the official website");
         }
 
-        public async Task<string> getForgeMD5(string mcVersion, string forgeVersion)
-        {
-            var document = new HtmlDocument();
-            var html = await httpClient.GetStringAsync($"https://files.minecraftforge.net/net/minecraftforge/forge/index_{mcVersion}.html");
-            document.LoadHtml(html);
-            var rows = document.DocumentNode.SelectNodes("//html[1]//body[1]//main[1]//div[2]//div[2]//div[2]//table[1]//tbody[1]//tr").ToList();
-            foreach (var row in rows)
-            {
-                var current_version = ClearName(row.Descendants(0).Where(n => n.HasClass("download-version")).FirstOrDefault().FirstChild.OuterHtml.Replace(" ", ""));
-                if (current_version == forgeVersion)
-                    return ClearName(row.ChildNodes[5].ChildNodes[1].ChildNodes[3].ChildNodes[5].ChildNodes[2].InnerText);
-            }
-            return "404";
-        }
 
         private string getAdUrl() =>
             $"https://adfoc.us/serve/sitelinks/?id=271228&url=https://maven.minecraftforge.net/";

--- a/CmlLib/Core/Installer/MForge.cs
+++ b/CmlLib/Core/Installer/MForge.cs
@@ -11,189 +11,149 @@ using System.Linq;
 using System.Net;
 using System.Text;
 
+using CmlLib.Utils;
+using HtmlAgilityPack;
+using ICSharpCode.SharpZipLib.Zip;
+using MCQuery;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+using System.Web;
+using CmlLib.Core.Downloader;
+using CmlLib.Core.Files;
+using CmlLib.Core.Installer;
+using CmlLib.Core.Version;
+using Directory = System.IO.Directory;
+using File = System.IO.File;
+
 namespace CmlLib.Core.Installer
 {
     public class MForge
     {
-        private const string MavenServer = "https://maven.minecraftforge.net/net/minecraftforge/forge/";
-
-        public static string GetOldForgeName(string mcVersion, string forgeVersion)
-        {
-            return $"{mcVersion}-forge{mcVersion}-{forgeVersion}";
-        }
-
-        public static string GetForgeName(string mcVersion, string forgeVersion)
-        {
-            return $"{mcVersion}-forge-{forgeVersion}";
-        }
-
-        public MForge(MinecraftPath mc, string java)
-        {
-            this.minecraftPath = mc;
-            JavaPath = java;
-            downloader = new SequenceDownloader();
-        }
-
-        public string JavaPath { get; private set; }
-        private readonly MinecraftPath minecraftPath;
+         private readonly MinecraftPath minecraftPath;
+        private readonly string JavaPath;
+        private CMLauncher launcher;
+        private static HttpClient httpClient = new HttpClient();
         private readonly IDownloader downloader;
         public event DownloadFileChangedHandler? FileChanged;
         public event EventHandler<string>? InstallerOutput;
 
-        public string InstallForge(string mcVersion, string forgeVersion)
+        public IForge(MinecraftPath mc, CMLauncher launcher, string java)
         {
-            var minecraftJar = minecraftPath.GetVersionJarPath(mcVersion);
-            if (!File.Exists(minecraftJar))
-                throw new IOException($"Install {mcVersion} first");
+            this.minecraftPath = mc;
+            this.JavaPath = java;
+            this.launcher = launcher;
+            downloader = new SequenceDownloader();
 
-            var installerPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        }
 
-            var installerStream = getInstallerStream(mcVersion, forgeVersion); // download installer
-            if (installerStream == null)
-                throw new InvalidOperationException("cannot open installer stream");
-            var extractedFile = extractInstaller(installerStream, installerPath); // extract installer
+        /* 1.7.10 - 1.9.4 */
+        public static string GetLegacyForgeName(string mcVersion, string forgeVersion) => $"forge-{mcVersion}-{forgeVersion}-{mcVersion}";
+        
+        /* 1.12 - *.*.* */
+        public static string GetForgeName(string mcVersion, string forgeVersion) => $"{mcVersion}-forge-{forgeVersion}";
 
-            var profileObj = extractedFile.Item1; // version profile json
-            var installerObj = extractedFile.Item2; // installer info
+        /*1.10 - 1.11.2 */
+        public static string GetOldForgeName(string mcVersion, string forgeVersion) => $"forge-{mcVersion}-{forgeVersion}";
 
-            // copy forge libraries to minecraft
-            extractMaven(installerPath); // new installer
+        /* 1.7.10 - 1.11.2 */
+        private static string GetLegacyFolderName(string mcVersion, string forgeVersion) => mcVersion == "1.7.10" ? 
+            $"{mcVersion}-Forge-{forgeVersion}-{mcVersion}" : 
+            $"{mcVersion}-forge{mcVersion}-{forgeVersion}";
 
-            var universalPath = installerObj["filePath"]?.ToString();
-            if (string.IsNullOrEmpty(universalPath))
-                throw new InvalidOperationException("filePath property in installer was null");
+        
+        public async Task<string> Install(string mcVersion, string forgeVersion, bool AlwaysUpdate = false) => IsOldType(mcVersion) ? 
+            await Legacy(mcVersion, forgeVersion, AlwaysUpdate) : 
+            await Newest(mcVersion, forgeVersion, AlwaysUpdate);
+
+
+        private async Task<string> Newest(string mcVersion, string forgeVersion, bool AlwaysUpdate = false)
+        {
+            if (!AlwaysUpdate && Directory.Exists(Path.Combine(minecraftPath.Versions, GetForgeName(mcVersion, forgeVersion))))
+                return GetForgeName(mcVersion, forgeVersion); //the version is already installed
+
+            var version_jar = minecraftPath.GetVersionJarPath(mcVersion); // get vanilla jar file
+            var install_folder = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName()); //create folder in temp
+            if (!System.IO.File.Exists(version_jar))
+                await launcher.CheckAndDownloadAsync(launcher.GetVersion(mcVersion)); //install vanilla version
+
+            await DownloadFile(mcVersion, forgeVersion, install_folder); //download forge version
+            File.Copy(Path.Combine(install_folder, "installer.jar"), Path.Combine(install_folder, "version.zip"));
+            new FastZip().ExtractZip(Path.Combine(install_folder, "version.zip"), install_folder, null); //unzip version
             
-            var destPath = installerObj["path"]?.ToString();
-            if (string.IsNullOrEmpty(destPath))
-                throw new InvalidOperationException("path property in installer was null");
-            
-            extractUniversal(installerPath, universalPath, destPath); // old installer
+            var version = JObject.Parse(File.ReadAllText(Path.Combine(install_folder, "version.json")));
+            var installer = JObject.Parse(File.ReadAllText(Path.Combine(install_folder, "install_profile.json")));
+            var installerData = installer["data"] as JObject;
+            var mapData = installerData == null ? new Dictionary<string, string?>() : mapping(installerData, "client", version_jar, install_folder);
 
-            // download libraries and processors
-            checkLibraries(installerObj["libraries"] as JArray);
+            extractMaven(install_folder); //setup maven
+            await checkLibraries(installer["libraries"] as JArray); //install libs
+            process(installer["processors"] as JArray, mapData, install_folder);
+            setupFolder(mcVersion, forgeVersion, install_folder, version.ToString()); //copy version.json and forge.jar
 
-            // mapping client data
-            var installerData = installerObj["data"] as JObject;
-            var mapData = (installerData == null) 
-                ? new Dictionary<string, string?>()
-                : mapping(installerData, "client", minecraftJar, installerPath);
+            //########################AD URL##############################
+            Process.Start(getAdUrl()); //We support Forge developers!
+            //########################AD URL##############################
 
-            // process
-            process(installerObj["processors"] as JArray, mapData);
-
-            // version name like 1.16.2-forge-33.0.20
-            var versionName = installerObj["target"]?.ToString()
-                           ?? installerObj["version"]?.ToString()
-                           ?? GetForgeName(mcVersion, forgeVersion);
-
-            var versionPath = minecraftPath.GetVersionJsonPath(versionName);
-
-            // write version profile json
-            writeProfile(profileObj, versionPath);
-
-            return versionName;
+            await launcher.GetAllVersionsAsync(); //update version list
+            return GetForgeName(mcVersion, forgeVersion);
         }
 
-        private Stream? getInstallerStream(string mcVersion, string forgeVersion)
+
+        private async Task<string> Legacy(string mcVersion, string forgeVersion, bool AlwaysUpdate = false)
         {
-            fireEvent(MFile.Library, "installer", 1, 0);
+            if (!AlwaysUpdate && Directory.Exists(Path.Combine(minecraftPath.Versions, GetLegacyFolderName(mcVersion, forgeVersion))))
+                return $"{GetLegacyFolderName(mcVersion, forgeVersion)}";
 
-            var url = $"{MavenServer}{mcVersion}-{forgeVersion}/" +
-                $"forge-{mcVersion}-{forgeVersion}-installer.jar";
+            var version_jar = minecraftPath.GetVersionJarPath(mcVersion); // get vanilla jar file
+            var install_folder = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName()); //create folder in temp
+            if (!System.IO.File.Exists(version_jar))
+                await launcher.CheckAndDownloadAsync(launcher.GetVersion(mcVersion)); //install vanilla version
 
-            return WebRequest.Create(url).GetResponse().GetResponseStream();
+            await DownloadFile(mcVersion, forgeVersion, install_folder); //download forge version
+            File.Copy(Path.Combine(install_folder, "installer.jar"), Path.Combine(install_folder, "version.zip"));
+            new FastZip().ExtractZip(Path.Combine(install_folder, "version.zip"), install_folder, null); //unzip version
+
+            var installer = JObject.Parse(File.ReadAllText(Path.Combine(install_folder, "install_profile.json")));
+            var version = installer["versionInfo"] as JObject;
+            var installerData = installer["data"] as JObject;
+            var mapData = installerData == null ? new Dictionary<string, string?>() : mapping(installerData, "client", version_jar, install_folder);
+            var version_name = version["id"].ToString();
+            var destPath = (installer["install"] as JObject)["path"]?.ToString();
+            var universalPath = (installer["install"] as JObject)["filePath"]?.ToString();
+
+            if (string.IsNullOrEmpty(universalPath)) throw new InvalidOperationException("filePath property in installer was null");
+            if (string.IsNullOrEmpty(destPath)) throw new InvalidOperationException("path property in installer was null");
+
+            extractUniversal(install_folder, universalPath, destPath); // old installer
+            await checkLibraries(installer["libraries"] as JArray); //install libs
+            process(installer["processors"] as JArray, mapData, install_folder);
+            setupFolderLegacy(mcVersion, forgeVersion, install_folder, version_name, version.ToString()); //copy version.json and forge.jar
+
+            //########################AD URL##############################
+            Process.Start(getAdUrl()); //We support Forge developers!
+            //########################AD URL##############################
+
+            await launcher.GetAllVersionsAsync(); //update version list
+            return version_name;
         }
 
-        private Tuple<JToken, JToken> extractInstaller(Stream stream, string extractPath)
-        {
-            // extract installer
-            string? installProfile = null;
-            string? versionsJson = null;
-
-            using (stream)
-            using (var s = new ZipInputStream(stream))
-            {
-                ZipEntry e;
-                while ((e = s.GetNextEntry()) != null)
-                {
-                    if (e.Name.Length <= 0)
-                        continue;
-
-                    var realpath = Path.Combine(extractPath, e.Name);
-
-                    if (e.IsFile)
-                    {
-                        if (e.Name == "install_profile.json")
-                            installProfile = readStreamString(s);
-                        else if (e.Name == "version.json")
-                            versionsJson = readStreamString(s);
-                        else
-                        {
-                            var dirPath = Path.GetDirectoryName(realpath);
-                            if (!string.IsNullOrEmpty(dirPath))
-                                Directory.CreateDirectory(dirPath);
-
-                            using var fs = File.OpenWrite(realpath);
-                            s.CopyTo(fs);
-                        }
-                    }
-                }
-            }
-
-            if (installProfile == null)
-                throw new InvalidOperationException("no install_profile.json in installer");
-            if (versionsJson == null)
-                throw new InvalidOperationException("no version.json in installer");
-            
-            JToken profileObj;
-            var installObj = JObject.Parse(installProfile); // installer info
-            var versionInfo = installObj["versionInfo"]; // version profile
-
-            if (versionInfo == null)
-                profileObj = JObject.Parse(versionsJson);
-            else
-            {
-                installObj = installObj["install"] as JObject;
-                profileObj = versionInfo;
-            }
-
-            if (installObj == null)
-                throw new InvalidOperationException("no 'install' object in install_profile.json");
-
-            return new Tuple<JToken, JToken>(profileObj, installObj);
-        }
-
-        private string readStreamString(Stream s)
-        {
-            var str = new StringBuilder();
-            var buffer = new byte[1024];
-            while (true)
-            {
-                int size = s.Read(buffer, 0, buffer.Length);
-                if (size == 0)
-                    break;
-
-                str.Append(Encoding.UTF8.GetString(buffer, 0, size));
-            }
-
-            return str.ToString();
-        }
-
-        // for new installer
         private void extractMaven(string installerPath)
         {
-            fireEvent(MFile.Library, "maven", 1, 0);
-
-            // copy all libraries in maven (include universal) to minecraft
             var org = Path.Combine(installerPath, "maven");
             if (Directory.Exists(org))
                 IOUtil.CopyDirectory(org, minecraftPath.Library, true);
         }
 
-        // for old installer
         private void extractUniversal(string installerPath, string universalPath, string destinyName)
         {
-            fireEvent(MFile.Library, "universal", 1, 0);
 
             if (string.IsNullOrEmpty(universalPath) || string.IsNullOrEmpty(destinyName))
                 return;
@@ -212,43 +172,41 @@ namespace CmlLib.Core.Installer
             }
         }
 
-        // legacy
-        private void downloadUniversal(string mcVersion, string forgeVersion)
+        private Task checkLibraries(JArray? jarr)
         {
-            fireEvent(MFile.Library, "universal", 1, 0);
+            if (jarr == null || jarr.Count == 0)
+                return Task.CompletedTask;
 
-            var forgeName = $"forge-{mcVersion}-{forgeVersion}";
-            var baseUrl = $"{MavenServer}{mcVersion}-{forgeVersion}";
+            var libs = new List<MLibrary>();
+            var parser = new MLibraryParser();
+            foreach (var item in jarr)
+            {
+                var parsedLib = parser.ParseJsonObject((JObject)item);
+                if (parsedLib != null)
+                    libs.AddRange(parsedLib);
+            }
 
-            var universalUrl = $"{baseUrl}/{forgeName}-universal.jar";
-            var universalPath = Path.Combine(
-                minecraftPath.Library,
-                "net",
-                "minecraftforge",
-                "forge",
-                $"{mcVersion}-{forgeVersion}",
-                $"forge-{mcVersion}-{forgeVersion}.jar"
-            );
+            var fileProgress = new Progress<DownloadFileChangedEventArgs>(
+                e => FileChanged?.Invoke(e));
 
-            var dirPath = Path.GetDirectoryName(universalPath);
-            if (!string.IsNullOrEmpty(dirPath))
-                Directory.CreateDirectory(dirPath);
-            
-            var dl = new WebDownload();
-            dl.DownloadFile(universalUrl, universalPath);
+            var libraryChecker = new LibraryChecker();
+            var lostLibrary = libraryChecker.CheckFiles(minecraftPath, libs.ToArray(), fileProgress);
+
+            if (lostLibrary == null)
+                return Task.CompletedTask;
+            downloader.DownloadFiles(lostLibrary, fileProgress, null).GetAwaiter().GetResult();
+            return Task.CompletedTask;
         }
 
         private Dictionary<string, string?> mapping(JObject data, string kind,
             string minecraftJar, string installerPath)
         {
-            // convert [path] to absolute path
-
             var dataMapping = new Dictionary<string, string?>();
             foreach (var item in data)
             {
                 var key = item.Key;
                 var value = item.Value?[kind]?.ToString();
-                
+
                 if (string.IsNullOrEmpty(value))
                     continue;
 
@@ -268,36 +226,11 @@ namespace CmlLib.Core.Installer
             return dataMapping;
         }
 
-        private void checkLibraries(JArray? jarr)
-        {
-            if (jarr == null || jarr.Count == 0)
-                return;
-
-            var libs = new List<MLibrary>();
-            var parser = new MLibraryParser();
-            foreach (var item in jarr)
-            {
-                var parsedLib = parser.ParseJsonObject((JObject)item);
-                if (parsedLib != null)
-                    libs.AddRange(parsedLib);
-            }
-
-            var fileProgress = new Progress<DownloadFileChangedEventArgs>(
-                e => FileChanged?.Invoke(e));
-            
-            var libraryChecker = new LibraryChecker();
-            var lostLibrary = libraryChecker.CheckFiles(minecraftPath, libs.ToArray(), fileProgress);
-            
-            if (lostLibrary != null)
-                downloader.DownloadFiles(lostLibrary, fileProgress, null);
-        }
-
-        private void process(JArray? processors, Dictionary<string, string?> mapData)
+        private void process(JArray? processors, Dictionary<string, string?> mapData, string install_folder)
         {
             if (processors == null || processors.Count == 0)
                 return;
 
-            fireEvent(MFile.Library, "processors", processors.Count, 0);
 
             for (int i = 0; i < processors.Count; i++)
             {
@@ -305,9 +238,9 @@ namespace CmlLib.Core.Installer
 
                 var outputs = item["outputs"] as JObject;
                 if (outputs == null || !checkProcessorOutputs(outputs, mapData))
-                    startProcessor(item, mapData);
+                    if (item["sides"] == null || (item["sides"] as JArray)[0].ToString() == "client") //skip server side
+                        startProcessor(item, mapData, install_folder);
 
-                fireEvent(MFile.Library, "processors", processors.Count, i + 1);
             }
         }
 
@@ -317,7 +250,7 @@ namespace CmlLib.Core.Installer
             {
                 if (item.Value == null)
                     continue;
-                
+
                 var key = Mapper.Interpolation(item.Key, mapData, true);
                 var value = Mapper.Interpolation(item.Value.ToString(), mapData, true);
 
@@ -328,7 +261,7 @@ namespace CmlLib.Core.Installer
             return true;
         }
 
-        private void startProcessor(JToken processor, Dictionary<string, string?> mapData)
+        private void startProcessor(JToken processor, Dictionary<string, string?> mapData, string install_folder)
         {
             var name = processor["jar"]?.ToString();
             if (name == null)
@@ -357,7 +290,7 @@ namespace CmlLib.Core.Installer
                     var libNameString = libName?.ToString();
                     if (string.IsNullOrEmpty(libNameString))
                         continue;
-                    
+
                     var lib = Path.Combine(minecraftPath.Library,
                         PackageName.Parse(libNameString).GetPath());
                     classpath.Add(lib);
@@ -374,37 +307,125 @@ namespace CmlLib.Core.Installer
                 args = Mapper.Map(arrStrs, mapData, minecraftPath.Library);
             }
 
-            startJava(classpath.ToArray(), mainClass, args);
+            startJava(classpath.ToArray(), mainClass, args, install_folder);
         }
 
-        private void startJava(string[] classpath, string mainClass, string[]? args)
+        private void startJava(string[] classpath, string mainClass, string[]? args, string install_folder)
         {
+            for (int i = 0; i < args.Length; i++)
+                if (args[i] == "{INSTALLER}")
+                    args[i] = args[i].Replace("{INSTALLER}", Path.Combine(install_folder, "installer.jar"));
             var arg =
                 $"-cp {IOUtil.CombinePath(classpath)} " +
                 $"{mainClass}";
 
             if (args != null && args.Length > 0)
                 arg += " " + string.Join(" ", args);
-            
+
             var process = new Process();
             process.StartInfo = new ProcessStartInfo()
             {
                 FileName = JavaPath,
-                Arguments = arg,
+                Arguments = arg.Replace("--side CLIENT", "--side client"), //fix installertools bug
             };
 
             var p = new ProcessUtil(process);
-            p.OutputReceived += (s, e) => InstallerOutput?.Invoke(this, e);
+            p.OutputReceived += (s, e) => 
+            InstallerOutput?.Invoke(this, e);
             p.StartWithEvents();
             p.Process.WaitForExit();
         }
 
-        private void writeProfile(JToken profileObj, string versionPath)
+        private bool IsOldType(string mcVersion) => Convert.ToInt32(mcVersion.Split('.')[1]) < 12 ? true : false;
+
+        private void setupFolder(string mcVersion, string forgeVersion, string install_folder, string JVersion)
         {
-            var dirPath = Path.GetDirectoryName(versionPath);
-            if (!string.IsNullOrEmpty(dirPath))
-                Directory.CreateDirectory(dirPath);
-            File.WriteAllText(versionPath, profileObj.ToString());
+            string version_folder = Path.Combine(minecraftPath.Versions, GetForgeName(mcVersion, forgeVersion));
+            if(Directory.Exists(version_folder))
+                Directory.Delete(version_folder, true); //remove version folder
+            Directory.CreateDirectory(version_folder); //create version folder
+            File.WriteAllText(Path.Combine(version_folder, $"{GetForgeName(mcVersion, forgeVersion)}.json"), JVersion); //write version.json
+            var jar = Path.Combine(install_folder, $"maven\\net\\minecraftforge\\forge\\{mcVersion}-{forgeVersion}\\forge-{mcVersion}-{forgeVersion}.jar");
+            if (File.Exists(jar)) //fix 1.17+ errors
+                File.Copy(jar, Path.Combine(version_folder, $"{GetForgeName(mcVersion, forgeVersion)}.jar")); //copy jar file
+            Directory.Delete(install_folder, true); //remove temp folder
+        }
+
+        private void setupFolderLegacy(string mcVersion, string forgeVersion, string install_folder, string version_name, string JVersion)
+        {
+            string version_folder = Path.Combine(minecraftPath.Versions, version_name);
+            var universal_jar = Convert.ToInt32(mcVersion.Split('.')[1]) < 10 ?
+                $"{GetLegacyForgeName(mcVersion, forgeVersion)}-universal.jar" :
+                $"{GetOldForgeName(mcVersion, forgeVersion)}-universal.jar";
+
+            if (Directory.Exists(version_folder))
+                Directory.Delete(version_folder, true); //remove version folder
+            Directory.CreateDirectory(version_folder); //create version folder
+
+            File.Copy(Path.Combine(install_folder, universal_jar),
+                Path.Combine(version_folder, $"{version_name}.jar")); //copy jar file
+            File.WriteAllText(Path.Combine(version_folder, $"{version_name}.json"), JVersion); //write version.json
+            Directory.Delete(install_folder, true); //remove temp folder
+        }
+
+        public async Task<string> getForgeUrl(string mcVersion, string forgeVersion)
+        {
+            var document = new HtmlDocument();
+            var html = await httpClient.GetStringAsync($"https://files.minecraftforge.net/net/minecraftforge/forge/index_{mcVersion}.html");
+            document.LoadHtml(html);
+            var rows = document.DocumentNode.SelectNodes("//html[1]//body[1]//main[1]//div[2]//div[2]//div[2]//table[1]//tbody[1]//tr").ToList();
+            foreach (var row in rows)
+            {
+                var current_version = ClearName(row.Descendants(0).Where(n => n.HasClass("download-version")).FirstOrDefault().FirstChild.OuterHtml.Replace(" ", ""));
+                if (current_version == forgeVersion)
+                    return GetQueryString(row.ChildNodes[5].ChildNodes[1].ChildNodes[3].ChildNodes[3].Attributes["href"].Value, "url=");
+            }
+            throw new Exception("The version was not found on the official website");
+        }
+
+        public async Task<string> getForgeMD5(string mcVersion, string forgeVersion)
+        {
+            var document = new HtmlDocument();
+            var html = await httpClient.GetStringAsync($"https://files.minecraftforge.net/net/minecraftforge/forge/index_{mcVersion}.html");
+            document.LoadHtml(html);
+            var rows = document.DocumentNode.SelectNodes("//html[1]//body[1]//main[1]//div[2]//div[2]//div[2]//table[1]//tbody[1]//tr").ToList();
+            foreach (var row in rows)
+            {
+                var current_version = ClearName(row.Descendants(0).Where(n => n.HasClass("download-version")).FirstOrDefault().FirstChild.OuterHtml.Replace(" ", ""));
+                if (current_version == forgeVersion)
+                    return ClearName(row.ChildNodes[5].ChildNodes[1].ChildNodes[3].ChildNodes[5].ChildNodes[2].InnerText);
+            }
+            return "404";
+        }
+
+        private string getAdUrl() =>
+            $"https://adfoc.us/serve/sitelinks/?id=271228&url=https://maven.minecraftforge.net/";
+
+        private string ClearName(string name) => name.Replace(" ", "").Replace("\n", "");
+
+        private string GetQueryString(string url, string key)
+        {
+            int index = url.IndexOf('?');
+            var query = url.Substring(index + 1).Split('&').SingleOrDefault(s => s.StartsWith(key));
+            return query == null ? url : query.Replace(key, null);
+        }
+
+        private async Task DownloadFile(string mcVersion, string forgeVersion, string install_folder)
+        {
+            System.IO.Directory.CreateDirectory(install_folder);
+            var fileUrl = await getForgeUrl(mcVersion, forgeVersion);
+            var httpResult = await httpClient.GetAsync(fileUrl);
+            using var resultStream = await httpResult.Content.ReadAsStreamAsync();
+            using var fileStream = System.IO.File.Create(Path.Combine(install_folder, "installer.jar"));
+            resultStream.CopyTo(fileStream);
+        }
+
+        private static string CalculateMD5(string filename)
+        {
+            using var md5 = MD5.Create();
+            using var stream = File.OpenRead(filename);
+            var hash = md5.ComputeHash(stream);
+            return BitConverter.ToString(hash).Replace("-", "").ToLowerInvariant();
         }
 
         private void fireEvent(MFile kind, string name, int total, int progressed)

--- a/CmlLib/Core/Installer/MForge.cs
+++ b/CmlLib/Core/Installer/MForge.cs
@@ -8,28 +8,10 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Net;
-using System.Text;
-
-using CmlLib.Utils;
-using HtmlAgilityPack;
-using ICSharpCode.SharpZipLib.Zip;
-using MCQuery;
-using Newtonsoft.Json.Linq;
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
-using System.Linq;
 using System.Net.Http;
 using System.Security.Cryptography;
-using System.Text;
 using System.Threading.Tasks;
-using System.Web;
-using CmlLib.Core.Downloader;
-using CmlLib.Core.Files;
-using CmlLib.Core.Installer;
-using CmlLib.Core.Version;
+using HtmlAgilityPack;
 using Directory = System.IO.Directory;
 using File = System.IO.File;
 
@@ -37,7 +19,7 @@ namespace CmlLib.Core.Installer
 {
     public class MForge
     {
-         private readonly MinecraftPath minecraftPath;
+        private readonly MinecraftPath minecraftPath;
         private readonly string JavaPath;
         private CMLauncher launcher;
         private static HttpClient httpClient = new HttpClient();
@@ -45,7 +27,7 @@ namespace CmlLib.Core.Installer
         public event DownloadFileChangedHandler? FileChanged;
         public event EventHandler<string>? InstallerOutput;
 
-        public IForge(MinecraftPath mc, CMLauncher launcher, string java)
+        public MForge(MinecraftPath mc, CMLauncher launcher, string java)
         {
             this.minecraftPath = mc;
             this.JavaPath = java;


### PR DESCRIPTION
Hi! I wrote a new Forge installer where many bugs were fixed. 
✅The Forge developer support system has been added. After each use, the Forge advertising page opens

✅ Support for launching newest type versions (1.17 - 1.20.x)
⚠️ To install the latest versions, you must use Java 17.x.x, that is, when initializing the MForge object, you must specify the path to javaw.exe it is this version.
✅ Support for launching new type versions (1.12 - 1.16.x)
✅ Support for launching a version with a changed name (1.10 - 1.11.2)
✅ Support for running old-type versions (1.8 - 1.9.4)
✅ Support for running legacy-type version (1.7.10, others have not been tested)
✅ Automatic system for changing links from the minecraftforge.net
✅ Fixed the bug of installation errors of some versions due to parallel downloading and configuration. (The forge configuration files were used before they were downloaded.)
✅Quick launch of the version if it is already installed. You can disable it
✅Automatic installation of the vanilla version if it does not exist.
✅Fixed a bug installing the client side.

❌Does not have an action logging system
⚠️You need to install HtmlAgilityPack!!!

If you find bugs, then contact me @Tartilla_ (Discord)