### PR TITLE
ProcessWapper.StartWithEvents now supports dotnet 8.

### DIFF
--- a/src/ProcessBuilder/ProcessWrapper.cs
+++ b/src/ProcessBuilder/ProcessWrapper.cs
@@ -16,8 +16,8 @@ public class ProcessWrapper
 
     public void StartWithEvents()
     {
-        Process.StartInfo.CreateNoWindow = true;
-        Process.StartInfo.WindowStyle = ProcessWindowStyle.Hidden;
+        Process.StartInfo.CreateNoWindow = false;
+        Process.StartInfo.WindowStyle = ProcessWindowStyle.Normal;
         Process.StartInfo.UseShellExecute = false;
         Process.StartInfo.RedirectStandardError = true;
         Process.StartInfo.RedirectStandardOutput = true;


### PR DESCRIPTION
Due to a breaking change related to Process in dotnet 8, Minecraft will not start correctly when using the ProcessWapper.StartWithEvents method.

More information about this breaking change can be found [here](https://learn.microsoft.com/ja-jp/dotnet/core/compatibility/core-libraries/8.0/processstartinfo-windowstyle).

Until now, if StartInfo.ShellUse was set to false, WindowStyle.Normal was always used regardless of the WindowStyle setting, but from dotnet 8, the WindowStyle setting is applied even if it is false.

In ProcessWapper.StartWithEvents, WindowStyle is specified as Hidden, which means the Minecraft window is not displayed.

For this reason, WindowStyle has been changed to Normal.