### PR TITLE
Feature path separator

### DIFF
--- a/src/Internals/IOUtil.cs
+++ b/src/Internals/IOUtil.cs
@@ -16,11 +16,9 @@ internal static class IOUtil
             .TrimEnd(Path.DirectorySeparatorChar);
     }
 
-    public static string CombinePath(IEnumerable<string> paths)
+    public static string CombinePath(IEnumerable<string> paths, string pathSeparator)
     {
-        return string.Join(
-            Path.PathSeparator.ToString(),
-            paths.Select(Path.GetFullPath));
+        return string.Join(pathSeparator, paths.Select(Path.GetFullPath));
     }
 
     public static bool CheckFileValidation(string path, string? compareHash)

--- a/src/ProcessBuilder/MinecraftProcessBuilder.cs
+++ b/src/ProcessBuilder/MinecraftProcessBuilder.cs
@@ -99,7 +99,7 @@ public class MinecraftProcessBuilder
         Debug.Assert(launchOption.Session != null);
 
         var classpaths = getClasspaths(context);
-        var classpath = IOUtil.CombinePath(classpaths);
+        var classpath = IOUtil.CombinePath(classpaths, launchOption.PathSeparator);
         var assetId = version.GetInheritedProperty(version => version.AssetIndex?.Id) ?? "legacy";
         
         var argDict = new Dictionary<string, string?>

--- a/test/IOUtilTests.cs
+++ b/test/IOUtilTests.cs
@@ -33,7 +33,7 @@ public class IOUtilTest
         };
         var exp = @"C:\test\lib1.zip;""C:\test\lib space 2.zip""";
         
-        Assert.Equal(exp, IOUtil.CombinePath(paths));
+        Assert.Equal(exp, IOUtil.CombinePath(paths, Path.PathSeparator.ToString()));
     }
 
     [Fact(Skip = "Unix")]
@@ -45,6 +45,6 @@ public class IOUtilTest
         };
         var exp = @"/root/f1.zip:""/root/f2 space sss.txt""";
         
-        Assert.Equal(exp, IOUtil.CombinePath(paths));
+        Assert.Equal(exp, IOUtil.CombinePath(paths, Path.PathSeparator.ToString()));
     }
 }


### PR DESCRIPTION
At the stage of forming the command to launch Minecraft, a very convenient option to indicate ```PathSeparator ``` appeared.

However, it did not participate in the formation of the classPath.