### PR TITLE
Update API host, add QuiltTester, and fix property type

### DIFF
--- a/examples/console/Program.cs
+++ b/examples/console/Program.cs
@@ -18,19 +18,19 @@ class Program
         await p.Start();
         return;
 
-        //var path = new MinecraftPath("C:\\Users\\ksi12\\AppData\\Roaming\\minecraft test");
-        //var launcher = new MinecraftLauncher(path);
-
-        //var fabricTester = new FabricTester(path);
-        //await fabricTester.Test();
-        //return;
-
-        //var llTester = new LiteLoaderTester(launcher);
-        //await llTester.Test();
-        //return;
-
-        //var tester = new LauncherTester("b", launcher);
-        //await tester.Start();
+        // var path = new MinecraftPath("D:\\Games\\minecraft");
+        // var launcher = new MinecraftLauncher(path);
+        //
+        // var quiltTester = new QuiltTester(path);
+        // await quiltTester.LaunchOldest();
+        // return;
+        //
+        // var llTester = new LiteLoaderTester(launcher);
+        // await llTester.Test();
+        // return;
+        //
+        // var tester = new LauncherTester("b", launcher);
+        // await tester.Start();
     }
 
     private async Task Start()

--- a/examples/console/QuiltTester.cs
+++ b/examples/console/QuiltTester.cs
@@ -1,0 +1,53 @@
+﻿using CmlLib.Core;
+using CmlLib.Core.Auth;
+using CmlLib.Core.ModLoaders.FabricMC;
+using CmlLib.Core.ModLoaders.QuiltMC;
+using CmlLib.Core.ProcessBuilder;
+
+namespace CmlLibCoreSample;
+
+public class QuiltTester
+{
+    private readonly MinecraftPath _minecraftPath;
+
+    public QuiltTester(MinecraftPath minecraftPath) => _minecraftPath = minecraftPath;
+
+    public async Task Test()
+    {
+        var quiltInstaller = new QuiltInstaller(new HttpClient());
+        var versions = await quiltInstaller.GetSupportedVersionNames();
+
+        foreach (var version in versions) 
+        {
+            Console.WriteLine("Install " + version);
+            await quiltInstaller.Install(version, _minecraftPath);
+        }
+    }
+
+    public async Task LaunchLatest()
+    {
+        await Launch(versionSelector: versions => versions.First());
+    }
+
+    public async Task LaunchOldest()
+    {
+        await Launch(versionSelector: versions => versions.Last());
+    }
+
+    private async Task Launch(Func<IEnumerable<string>, string> versionSelector)
+    {
+        var launcher = new MinecraftLauncher(_minecraftPath);
+        var quiltInstaller = new QuiltInstaller(new HttpClient());
+
+        var versionTags = await quiltInstaller.GetSupportedVersionNames();
+        var versionName = await quiltInstaller.Install(versionSelector(versionTags), _minecraftPath);
+
+        var process = await launcher.InstallAndBuildProcessAsync(versionName, new MLaunchOption
+        {
+            Session = MSession.CreateOfflineSession("hello"),
+            MaximumRamMb = 4096
+        });
+
+        process.Start();
+    }
+}

--- a/src/ModLoaders/QuiltMC/QuiltInstaller.cs
+++ b/src/ModLoaders/QuiltMC/QuiltInstaller.cs
@@ -5,7 +5,7 @@ namespace CmlLib.Core.ModLoaders.QuiltMC;
 
 public class QuiltInstaller
 {
-    public static readonly string DefaultApiServerHost = "https://meta.Quiltmc.net";
+    public static readonly string DefaultApiServerHost = "https://meta.quiltmc.org";
     private readonly HttpClient _httpClient;
     private readonly string _host;
 

--- a/src/ModLoaders/QuiltMC/QuiltLoader.cs
+++ b/src/ModLoaders/QuiltMC/QuiltLoader.cs
@@ -7,7 +7,7 @@ namespace CmlLib.Core.ModLoaders.QuiltMC
         [JsonPropertyName("separator")]
         public string? Separator { get; set; }
         [JsonPropertyName("build")]
-        public string? Build { get; set; }
+        public int? Build { get; set; }
         [JsonPropertyName("maven")]
         public string? Maven { get; set; }
         [JsonPropertyName("version")]


### PR DESCRIPTION
Updated the default API server host in `QuiltInstaller` to use `.org` instead of `.net`. Added a `QuiltTester` example for testing and launching Quilt versions. Modified the `Build` property type in `QuiltLoader` from `string?` to `int?` for accuracy.