### PR TITLE
Refactor OS native library lookup logic.

### DIFF
--- a/src/Files/MLibrary.cs
+++ b/src/Files/MLibrary.cs
@@ -32,8 +32,10 @@ public record MLibrary
         if (string.IsNullOrEmpty(os.Name) || string.IsNullOrEmpty(os.Arch))
             throw new ArgumentException("Invalid LauncherOSRule: empty Name or Arch");
 
-        var classifierId = Natives?[os.Name]?.Replace("${arch}", os.Arch);
-        return classifierId;
+        if (Natives == null || !Natives.TryGetValue(os.Name, out var native) || string.IsNullOrEmpty(native))
+            return null;
+
+        return native.Replace("${arch}", os.Arch);
     }
 
     public MFileMetadata? GetNativeLibrary(LauncherOSRule os)

--- a/test/Version/JsonLibraryParserTests.cs
+++ b/test/Version/JsonLibraryParserTests.cs
@@ -480,4 +480,41 @@ public class JsonLibraryParserTests
         var winPath = lib?.GetNativeLibraryPath(new LauncherOSRule(LauncherOSRule.Windows, LauncherOSRule.X64, "10"));
         Assert.NotNull(winPath);
     }
+
+
+    // 1.7.2-Forge10.12.2.1161-mc172
+    public static readonly string native_library_for_osx = """
+{
+    "name": "org.lwjgl.lwjgl:lwjgl-platform:2.9.1-nightly-20131017",
+	"rules": [
+	    {
+		    "action": "allow",
+			"os": {
+			    "name": "osx"
+			}
+		}
+	],
+	"natives": {
+		"osx": "natives-osx"
+	},
+	"extract": {
+		"exclude": [
+			"META-INF/"
+		]
+	}
+}
+""";
+
+    [Fact]
+    public void get_native_library_on_unsupported_os()
+    {
+        using var jsonDocument = JsonDocument.Parse(native_library_without_classifiers);
+        var lib = JsonLibraryParser.Parse(jsonDocument.RootElement);
+
+        var win = lib?.GetNativeLibrary(new LauncherOSRule(LauncherOSRule.Windows, LauncherOSRule.X64, "10"));
+        Assert.Null(win); // return null instead of throwing an exception
+
+        var winPath = lib?.GetNativeLibraryPath(new LauncherOSRule(LauncherOSRule.Windows, LauncherOSRule.X64, "10"));
+        Assert.NotNull(winPath);
+    }
 }


### PR DESCRIPTION
Simplify and improve error handling in the native library lookup by checking for nulls and invalid values upfront. Replace unnecessary intermediate variable with a streamlined return statement for better clarity and maintainability.

These changes need to be included in version 4.0.5. They are required for older versions of the game (Forge).








